### PR TITLE
fix: common: exit plymouth before starting dm

### DIFF
--- a/radxa-system-config-common/etc/systemd/system/gdm.service.d/00-workaround-getty-blocked.conf
+++ b/radxa-system-config-common/etc/systemd/system/gdm.service.d/00-workaround-getty-blocked.conf
@@ -1,0 +1,11 @@
+# https://wiki.archlinux.org/title/Plymouth#Smooth_transition
+# To fix getty startup being blocked when HDMI is not connected
+
+[Unit]
+Conflicts=plymouth-quit.service
+After=plymouth-quit.service rc-local.service plymouth-start.service systemd-user-sessions.service
+OnFailure=plymouth-quit.service
+
+[Service]
+ExecStartPre=-/usr/bin/plymouth deactivate
+ExecStartPost=-/usr/bin/plymouth quit --retain-splash

--- a/radxa-system-config-common/etc/systemd/system/sddm.service.d/00-workaround-slow-shutdown.conf
+++ b/radxa-system-config-common/etc/systemd/system/sddm.service.d/00-workaround-slow-shutdown.conf
@@ -1,0 +1,4 @@
+# NOTE: https://github.com/sddm/sddm/issues/1476#issuecomment-1140615746
+
+[Service]
+TimeoutStopSec=5s

--- a/radxa-system-config-common/etc/systemd/system/sddm.service.d/override.conf
+++ b/radxa-system-config-common/etc/systemd/system/sddm.service.d/override.conf
@@ -1,2 +1,0 @@
-[Service]
-TimeoutStopSec=5s


### PR DESCRIPTION
To fix getty startup being blocked when HDMI is not connected