### PR TITLE
fix: Add more cpu freq governors

### DIFF
--- a/debian/radxa-system-config-common.postinst
+++ b/debian/radxa-system-config-common.postinst
@@ -47,6 +47,11 @@ extcon-pd-virtual
 # Load Rockchip CPU Freq driver, which has no matching Device Tree node
 rockchip-cpufreq
 
+# Load CPU Freq governor
+cpufreq_conservative
+cpufreq_powersave
+cpufreq_userspace
+
 ### END OF RADXA-SYSTEM-CONFIG-COMMON SECTION
 EOF
         fi


### PR DESCRIPTION
Tested on Radxa Cubie A7Z.

Without this patch, we can see
  root@radxa-cubie-a7z:~# cat /sys/bus/cpu/devices/cpu0/cpufreq/scaling_available_governors
  ondemand performance schedutil

With this patch, we can see
  root@radxa-cubie-a7z:~# cat /sys/bus/cpu/devices/cpu0/cpufreq/scaling_available_governors
  userspace powersave conservative ondemand performance schedutil