### PR TITLE
fix: prioritize using Parole to play videos

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,6 +20,7 @@ Package: radxa-system-config-allwinner
 Architecture: all
 Priority: optional
 Depends: radxa-system-config,
+         parole,
          ${misc:Depends},
 Description: Allwinner system config files
  This package provides system config files for Allwinner devices.

--- a/radxa-system-config-allwinner/usr/share/applications/mimeapps.list
+++ b/radxa-system-config-allwinner/usr/share/applications/mimeapps.list
@@ -4,3 +4,6 @@ x-scheme-handler/about=chromium-browser.desktop
 x-scheme-handler/http=chromium-browser.desktop
 x-scheme-handler/https=chromium-browser.desktop
 x-scheme-handler/unknown=chromium-browser.desktop
+video/mp2t=org.xfce.Parole.desktop
+video/mp4=org.xfce.Parole.desktop
+video/x-matroska=org.xfce.Parole.desktop


### PR DESCRIPTION
Due to desktop acceleration conflicts with phonon4qt5-backend-gstreamer, so using Parole as an Alternative

Link: https://github.com/RadxaOS-SDK/rsdk/commit/2bdf2bd969299adb04a94e77b70c0c0e35c7f767