### PR TITLE
fix: set force_gl_vendor to notfreedreno for qualcomm device

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -76,6 +76,14 @@ Depends: radxa-system-config-rockchip,
 Description: Rockchip X.org config files
  This package provides system config files for Rockchip X.org exa acceleration.
 
+Package: radxa-system-config-qualcomm
+Architecture: all
+Priority: optional
+Depends: radxa-system-config,
+         ${misc:Depends},
+Description: Qualcomm system config files
+ This package provides system config files for Qualcomm devices.
+
 Package: radxa-system-config-common
 Architecture: all
 Priority: optional

--- a/debian/radxa-system-config-qualcomm.install
+++ b/debian/radxa-system-config-qualcomm.install
@@ -1,0 +1,1 @@
+radxa-system-config-qualcomm/usr /

--- a/radxa-system-config-qualcomm/usr/lib/environment.d/99-force-gl-vendor.conf
+++ b/radxa-system-config-qualcomm/usr/lib/environment.d/99-force-gl-vendor.conf
@@ -1,0 +1,3 @@
+# BaseVertex draws with client attributes are broken
+# ref: https://issues.angleproject.org/issues/431097618
+force_gl_vendor="notfreedreno"


### PR DESCRIPTION
use env var `force_gl_vendor="notfreedreno"` can fix the problem that causes rendering errors in chromium 138+. 

issue: https://gitlab.freedesktop.org/mesa/mesa/-/issues/13760
reference: https://issues.angleproject.org/issues/431097618