### PR TITLE
Revert "feat: enable rk3399 bcmdhd driver for ap6256/cm256sm"

### DIFF
--- a/radxa-system-config-rockchip/usr/lib/modprobe.d/bcmdhd.conf
+++ b/radxa-system-config-rockchip/usr/lib/modprobe.d/bcmdhd.conf
@@ -10,4 +10,3 @@
 alias sdio:c*v02D0dA9A6*   bcmdhd   #ap6236/ap6212
 alias sdio:c*v02D0d4359*   bcmdhd   #ap6398s
 alias sdio:c*v02D0dAAE8*   bcmdhd   #ap7265s
-alias sdio:c*v02D0dA9BF*   bcmdhd   #ap6256/cm256sm


### PR DESCRIPTION
This reverts commit baf4cd17cfc37d3f39abbfa5cfe569cdd42cee95.