### PR TITLE
fix: add clk_ignore_unused to cmdline.ttyMSM0

### DIFF
--- a/.github/local/Makefile.local
+++ b/.github/local/Makefile.local
@@ -21,7 +21,7 @@ $(SRC-KCMD)/cmdline.ttyAML0: $(SRC-KCMD)/cmdline
 	echo "console=ttyAML0,115200n8 $(shell cat $(SRC-KCMD)/cmdline)" > "$@"
 
 $(SRC-KCMD)/cmdline.ttyMSM0: $(SRC-KCMD)/cmdline
-	echo "console=ttyMSM0,115200n8 $(shell cat $(SRC-KCMD)/cmdline)" > "$@"
+	echo "console=ttyMSM0,115200n8 clk_ignore_unused $(shell cat $(SRC-KCMD)/cmdline)" > "$@"
 
 $(SRC-KCMD)/cmdline.ttyS2: $(SRC-KCMD)/cmdline
 	echo "console=ttyS2,1500000n8 $(shell cat $(SRC-KCMD)/cmdline)" > "$@"


### PR DESCRIPTION
It is reported that on Dragon Q8B with HDMI device connected, the kernel keeps printing the following logs repeatedly.

  [    8.285201] arm-smmu 15000000.iommu: FSYNR0 = 00620021 [S1CBNDX=98 PNU PLVL=1]
  [    8.285215] arm-smmu 15000000.iommu: Unhandled context fault: fsr=0x402, iova=0xc6922a00, fsynr=0x620021, cbfrsynra=0x1000, cb=23
  [    8.285216] arm-smmu 15000000.iommu: FSR    = 00000402 [Format=2 TF], SID=0x1000

Adding parameter, clk_ignore_unused, helps fix the issue.

Link: https://applink.feishu.cn/client/message/link/open?token=Ami%2F2XW%2Fg4ADagHEghNATNo%3D