### PR TITLE
fix: add plymouth.enable=0 to ttyMSM0 cmdline

### DIFF
--- a/.github/local/Makefile.local
+++ b/.github/local/Makefile.local
@@ -21,7 +21,7 @@ $(SRC-KCMD)/cmdline.ttyAML0: $(SRC-KCMD)/cmdline
 	echo "console=ttyAML0,115200n8 $(shell cat $(SRC-KCMD)/cmdline)" > "$@"
 
 $(SRC-KCMD)/cmdline.ttyMSM0: $(SRC-KCMD)/cmdline
-	echo "console=ttyMSM0,115200n8 clk_ignore_unused $(shell cat $(SRC-KCMD)/cmdline)" > "$@"
+	echo "console=ttyMSM0,115200n8 clk_ignore_unused $(shell cat $(SRC-KCMD)/cmdline) plymouth.enable=0" > "$@"
 
 $(SRC-KCMD)/cmdline.ttyS2: $(SRC-KCMD)/cmdline
 	echo "console=ttyS2,1500000n8 $(shell cat $(SRC-KCMD)/cmdline)" > "$@"


### PR DESCRIPTION
simpledrm→msm DRM handoff causes Plymouth to hold a dead drm fd, blocking plymouth-quit-wait.service and freezing systemd. Disabling Plymouth via plymouth.enable=0 avoids the race entirely.