### PR TITLE
fix: prevent AC101/AC101B capture source from suspending

### DIFF
--- a/radxa-system-config-allwinner/usr/share/wireplumber/wireplumber.conf.d/51-sunxi-codec-nosuspend.conf
+++ b/radxa-system-config-allwinner/usr/share/wireplumber/wireplumber.conf.d/51-sunxi-codec-nosuspend.conf
@@ -1,0 +1,16 @@
+monitor.alsa.rules = [
+  {
+    matches = [
+      {
+        media.class = "Audio/Source"
+        api.alsa.card.name = "~^sunxi-ac101b?$"
+        api.alsa.pcm.stream = "capture"
+      }
+    ]
+    actions = {
+      update-props = {
+        session.suspend-timeout-seconds = 0
+      }
+    }
+  }
+]


### PR DESCRIPTION
Add a system-wide WirePlumber rule for sunxi-ac101/ac101b capture sources to disable ALSA source suspend. This avoids audio output loss triggered when the headset/internal mic source is suspended while playback is still active.

Bug: suspending capture can cause active playback to become silent.